### PR TITLE
Revert GitHub Action To Run Tests Without python-dotenv

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,6 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    environment: PRODUCTION
 
     steps:
     - uses: actions/checkout@v4
@@ -35,5 +36,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unnitest
+      env:
+        GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       run: |
         python -m unittest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,4 +36,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unnitest
       run: |
-        dotenv -- run python -m unittest
+        python -m unittest


### PR DESCRIPTION
Environment is guaranteed to be available via GitHub [configuration](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions), hence python-dotenv may only be optional for contributors who prefer to have use a .env file as opposed to updating their OS's environment variables.