### PR TITLE
Remove Old .rst Doc Files Before Rebuilding With Latest Content

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -29,6 +29,11 @@ jobs:
           # Navigate to the Sphinx documentation directory
           cd docs || exit
           
+                    
+          # Remove old .rst files
+          rm source/*.rst
+          
+          
           # Build the docs .rst files
           sphinx-apidoc -o source/ ../
           


### PR DESCRIPTION
Forcefully overwrite existing .rst files from sphinx-apidoc